### PR TITLE
fix: style the "No changes" label in the Diff panel

### DIFF
--- a/packages/workshop-app/app/utils/diff.server.ts
+++ b/packages/workshop-app/app/utils/diff.server.ts
@@ -65,7 +65,9 @@ function getFileCodeblocks(
 	type: string,
 ) {
 	if (!file.chunks.length) {
-		return [`No changes`]
+		return [
+			`<p className="m-0 p-4 border-b text-muted-foreground">No changes</p>`,
+		]
 	}
 	const filepath = diffPathToRelative(
 		file.type === 'RenamedFile' ? file.pathAfter : file.path,


### PR DESCRIPTION
- Fixes #212

## Changes

I've fixed that styles of that Markdown snippet to this:

<img width="692" alt="Screenshot 2024-08-01 at 19 23 35" src="https://github.com/user-attachments/assets/a79bb9dc-c897-4646-9471-d1c9667659a9">

- Added the same consistent padding;
- Marked the text as muted to highlight it's not something to pay attention to;
- Added bottom border to visually separate the standalone string from the following `<details>` of the next file in the diff. 
