### PR TITLE
docs: improve "development" docs

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -1,24 +1,35 @@
 # Development
 
-[workshop-app](https://github.com/epicweb-dev/workshop-app) repository contains
-simplified
-[example apps](https://github.com/epicweb-dev/workshop-app/tree/main/packages/example).<br/>
+The [`workshop-app`](https://github.com/epicweb-dev/workshop-app) repository
+already contains simplified
+[example apps](https://github.com/epicweb-dev/workshop-app/tree/main/packages/example)
+you can use while developing the workshop app itself.
+
 To test the epic workshop app with a real workshop, set the
 `EPICSHOP_CONTEXT_CWD` environment variable with the path of a workshop you have
-installed locally.
+installed locally. You can find examples of usage below.
 
-Unix example:
-`EPICSHOP_CONTEXT_CWD=/Users/kentcdodds/code/epicweb-dev/data-modeling`
+## Unix
 
-Windows PowerShell example:
-`$env:EPICSHOP_CONTEXT_CWD='"C:\Users\kentcdodds\code\epicweb-dev\data-modeling"'`
+```sh
+EPICSHOP_CONTEXT_CWD=/Users/kentcdodds/code/epicweb-dev/data-modeling npm run dev
+```
 
-Windows cmd example:
-`set EPICSHOP_CONTEXT_CWD='"C:\Users\kentcdodds\code\epicweb-dev\data-modeling"'`
+## Windows PowerShell
+
+```sh
+$env:EPICSHOP_CONTEXT_CWD='"C:\Users\kentcdodds\code\epicweb-dev\data-modeling"'
+npm run dev
+```
+
+> Note: On Windows, you must use backslashes `\`.
+
+## Windows cmd
+
+```sh
+set EPICSHOP_CONTEXT_CWD='"C:\Users\kentcdodds\code\epicweb-dev\data-modeling"'
+npm run dev
+```
 
 Make sure that if the path includes spaces, you wrap the path in quotes as shown
 above (note the use of single quotes wrapping the double quotes!).
-
-> Notice: On Windows, you must use a backslash `\`.
-
-Then, you can run `npm run dev` from the same terminal.


### PR DESCRIPTION
While contributing to the repo, I found the development instructions not working for me. Specifically, the `EPICSHOP_CONTEXT_CWD` env variable was not picked up by `npm run dev` if set separately in the path (current terminal).

Instead, what worked was to set that variable as a part of the `npm run dev` command itself. 

I've updated the `development.mdx` document to have the instructions that worked for me on MacOS. I've also structured other OS examples with headings to they are easier to find visually. Let me know if this makes sense to you. 