### PR TITLE
fix(firefox): Mocklogs[0] is undefined

### DIFF
--- a/packages/workshop-app/app/styles/app.css
+++ b/packages/workshop-app/app/styles/app.css
@@ -485,6 +485,7 @@ body {
 	margin-bottom: 0 !important;
 }
 
+// For Firefox tests: https://github.com/epicweb-dev/epicshop/pull/228#pullrequestreview-2363921488
 .radix-state-closed\:hidden[data-state='closed'] {
 	height: 0;
 	overflow: hidden;

--- a/packages/workshop-app/app/styles/app.css
+++ b/packages/workshop-app/app/styles/app.css
@@ -484,3 +484,9 @@ body {
 .prose callout-danger.notification {
 	margin-bottom: 0 !important;
 }
+
+.radix-state-closed\:hidden[data-state='closed'] {
+	height: 0;
+	overflow: hidden;
+	display: flex;
+}


### PR DESCRIPTION
Fixes https://github.com/epicweb-dev/react-fundamentals/issues/397

In exercises/07.forms/04.solution.submit/submit.test.ts (and most of the 07 lessons) we programmaticly click [submit] on the form, but in Firefox most events are blocked inside hidden iframes (submit(), click() etc.) due to a 23-year-old bug.

Instead of hiding the divs containing the iframes, this css fix simply resizes the test accordians to `height:0`.

Tests fine in Chrome, Brave, Safari and Firefox.