### PR TITLE
Update workshop CLI dependency handling

### DIFF
--- a/packages/workshop-cli/package.json
+++ b/packages/workshop-cli/package.json
@@ -31,7 +31,6 @@
   },
   "dependencies": {
     "@epic-web/workshop-utils": "file:../workshop-utils",
-    "@epic-web/workshop-app": "file:../workshop-app",
     "chalk": "^5.3.0",
     "close-with-grace": "^2.1.0",
     "get-port": "^7.1.0",


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Remove direct workshop app dependency from CLI and enhance app location discovery.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The CLI no longer directly depends on the workshop app, making it lighter. The app's location is now determined dynamically at runtime via a prioritized list: environment variable, CLI flag, Node.js resolution, or global installation. This PR also modernizes internal file system and process operations to use async/await with promise-based APIs and `node:` prefixed imports.