### PR TITLE
Fix GitHub link formatting

### DIFF
--- a/packages/workshop-app/app/routes/_app+/exercise+/$exerciseNumber_.$stepNumber.$type+/_layout.tsx
+++ b/packages/workshop-app/app/routes/_app+/exercise+/$exerciseNumber_.$stepNumber.$type+/_layout.tsx
@@ -404,7 +404,9 @@ export function ErrorBoundary() {
 				503: () => (
 					<div>
 						<h1>Service Unavailable</h1>
-						<p>Sorry, we're having a temporary problem. Please try again later.</p>
+						<p>
+							Sorry, we're having a temporary problem. Please try again later.
+						</p>
 						<button onClick={() => window.location.reload()}>Refresh</button>
 					</div>
 				),

--- a/packages/workshop-app/app/routes/launch-editor.tsx
+++ b/packages/workshop-app/app/routes/launch-editor.tsx
@@ -271,13 +271,15 @@ function LaunchGitHub({
 	}
 	if (file) {
 		const safePath = (s: string) => s.replace(/\\/g, '/')
+		// Convert tree to blob for individual files
+		const githubFileRoot = ENV.EPICSHOP_GITHUB_ROOT.replace('/tree/', '/blob/')
 		return (
 			<a
 				className="launch_button !no-underline"
 				href={
 					safePath(file).replace(
 						safePath(ENV.EPICSHOP_CONTEXT_CWD),
-						ENV.EPICSHOP_GITHUB_ROOT,
+						githubFileRoot,
 					) + (line ? `#L${line}` : '')
 				}
 				rel="noreferrer"
@@ -288,14 +290,16 @@ function LaunchGitHub({
 		)
 	}
 	const app = apps.find((a) => a.name === appName)
+	// Convert tree to blob for individual files
+	const githubFileRoot = ENV.EPICSHOP_GITHUB_ROOT.replace('/tree/', '/blob/')
 	const path = [
 		...(app?.relativePath.split(requestInfo.separator) ?? []),
-		appFile + (line ? `#L${line}` : ''),
+		appFile,
 	].join('/')
 	return (
 		<a
 			className="launch_button !no-underline"
-			href={`${ENV.EPICSHOP_GITHUB_ROOT}/${path}`}
+			href={`${githubFileRoot}/${path}${line ? `#L${line}` : ''}`}
 			rel="noreferrer"
 			target="_blank"
 		>

--- a/packages/workshop-app/app/routes/launch-editor.tsx
+++ b/packages/workshop-app/app/routes/launch-editor.tsx
@@ -292,14 +292,19 @@ function LaunchGitHub({
 	const app = apps.find((a) => a.name === appName)
 	// Convert tree to blob for individual files
 	const githubFileRoot = ENV.EPICSHOP_GITHUB_ROOT.replace('/tree/', '/blob/')
+
+	// Parse appFile to extract filename and line number (format: "filename,line,column")
+	const [filename, appFileLine] = appFile ? appFile.split(',') : ['', '']
+	const lineNumber = line || (appFileLine ? Number(appFileLine) : undefined)
+
 	const path = [
 		...(app?.relativePath.split(requestInfo.separator) ?? []),
-		appFile,
+		filename,
 	].join('/')
 	return (
 		<a
 			className="launch_button !no-underline"
-			href={`${githubFileRoot}/${path}${line ? `#L${line}` : ''}`}
+			href={`${githubFileRoot}/${path}${lineNumber ? `#L${lineNumber}` : ''}`}
 			rel="noreferrer"
 			target="_blank"
 		>

--- a/packages/workshop-cli/src/cli.ts
+++ b/packages/workshop-cli/src/cli.ts
@@ -327,7 +327,7 @@ async function updateCommand() {
 	const isDeployed =
 		process.env.EPICSHOP_DEPLOYED === 'true' ||
 		process.env.EPICSHOP_DEPLOYED === '1'
-	
+
 	if (isDeployed) {
 		console.log('❌ Updates are not available in deployed environments.')
 		process.exit(1)

--- a/packages/workshop-utils/src/git.server.ts
+++ b/packages/workshop-utils/src/git.server.ts
@@ -113,7 +113,10 @@ export async function checkForUpdatesCached() {
 export async function updateLocalRepo() {
 	const ENV = getEnv()
 	if (ENV.EPICSHOP_DEPLOYED) {
-		return { status: 'error', message: 'Updates are not available in deployed environments.' } as const
+		return {
+			status: 'error',
+			message: 'Updates are not available in deployed environments.',
+		} as const
 	}
 
 	const cwd = getWorkshopRoot()
@@ -192,10 +195,9 @@ export async function getLatestWorkshopAppVersion() {
 export async function checkForExerciseChanges() {
 	const cwd = getWorkshopRoot()
 	try {
-		const { stdout } = await execaCommand(
-			'git status --porcelain exercises/',
-			{ cwd },
-		)
+		const { stdout } = await execaCommand('git status --porcelain exercises/', {
+			cwd,
+		})
 		return stdout.trim().length > 0
 	} catch (error) {
 		console.error(


### PR DESCRIPTION
Fix GitHub file link formatting for deployed environments.

Previously, links included line/column information as `,line,column` (e.g., `index.tsx,4,1`) instead of the correct `#Lline` format (e.g., `index.tsx#L4`), because the `appFile` parameter was not parsed correctly. This PR now parses `appFile` to extract the filename and line number, and formats the URL correctly. It also ensures `tree` is converted to `blob` for individual file links.