### PR TITLE
Update child port after restart

### DIFF
--- a/example/epicshop/package-lock.json
+++ b/example/epicshop/package-lock.json
@@ -81,6 +81,7 @@
         "remix-flat-routes": "^0.8.5",
         "remix-utils": "^8.7.0",
         "satori": "^0.15.2",
+        "semver": "^7.7.2",
         "shell-quote": "^1.8.3",
         "sonner": "^2.0.6",
         "source-map-support": "^0.5.21",


### PR DESCRIPTION
Reset child port tracking on server restart to ensure the 'open' command uses the correct port.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-5a421fdb-53fe-4eae-8d72-f39789fec71b) · [Cursor](https://cursor.com/background-agent?bcId=bc-5a421fdb-53fe-4eae-8d72-f39789fec71b)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)