### PR TITLE
Fix epicshop zod schema issue 315

### DIFF
--- a/packages/workshop-app/app/components/user.tsx
+++ b/packages/workshop-app/app/components/user.tsx
@@ -18,12 +18,14 @@ export function useUser() {
 
 export function useOptionalDiscordMember() {
 	const data = useRouteLoaderData('root') as RootLoaderData
-	return data?.user?.discordProfile
+	return data?.user?.discordProfile?.user
 		? {
 				id: data.user.discordProfile.user.id,
 				displayName:
 					data.user.discordProfile.nick ??
-					data.user.discordProfile.user.global_name,
+					data.user.discordProfile.user.global_name ??
+					data.user.name ??
+					data.user.email,
 				avatarUrl: data.user.imageUrlLarge,
 			}
 		: null

--- a/packages/workshop-utils/src/epic-api.server.ts
+++ b/packages/workshop-utils/src/epic-api.server.ts
@@ -588,13 +588,15 @@ const UserInfoSchema = z
 		image: z.string().nullable(),
 		discordProfile: z
 			.object({
-				nick: z.string().nullable(),
-				user: z.object({
-					id: z.string(),
-					username: z.string(),
-					avatar: z.string().nullable().optional(),
-					global_name: z.string().nullable().optional(),
-				}),
+				nick: z.string().nullable().optional(),
+				user: z
+					.object({
+						id: z.string(),
+						username: z.string(),
+						avatar: z.string().nullable().optional(),
+						global_name: z.string().nullable().optional(),
+					})
+					.optional(),
 			})
 			.nullable()
 			.optional(),


### PR DESCRIPTION
Relax Zod schema for `discordProfile` and add fallbacks to `useOptionalDiscordMember` to fix ZodError on startup.

The upstream API can return `discordProfile.nick` and `discordProfile.user` as undefined, causing a Zod validation error. This change makes these fields optional in the schema and updates the UI hook to safely access them and provide display name fallbacks.

---
<a href="https://cursor.com/background-agent?bcId=bc-f12d26be-0644-4227-83ed-7fefeffa6005">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f12d26be-0644-4227-83ed-7fefeffa6005">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

