### PR TITLE
fix: properly extract titles with backticks in MDX headings

### DIFF
--- a/packages/workshop-utils/src/compile-mdx.server.ts
+++ b/packages/workshop-utils/src/compile-mdx.server.ts
@@ -5,7 +5,7 @@ import path from 'path'
 import { rehypeCodeBlocksShiki } from '@kentcdodds/md-temp'
 import { type Element, type Root as HastRoot } from 'hast'
 import lz from 'lz-string'
-import { type Root as MdastRoot } from 'mdast'
+import { type Root as MdastRoot, type PhrasingContent } from 'mdast'
 import { type MdxJsxFlowElement } from 'mdast-util-mdx-jsx'
 import { bundleMDX } from 'mdx-bundler'
 import PQueue from 'p-queue'
@@ -232,8 +232,8 @@ async function compileMdxImpl(file: string): Promise<{
 							if (title) return
 							if (node.depth === 1) {
 								// Extract plain text content, preserving inline code but stripping other formatting
-								const extractText = (nodes: any[]): string => {
-									return nodes.map((childNode) => {
+								const extractText = (nodes: PhrasingContent[]): string => {
+									return nodes.map((childNode: PhrasingContent) => {
 										if (childNode.type === 'text') {
 											return childNode.value
 										} else if (childNode.type === 'inlineCode') {
@@ -241,7 +241,7 @@ async function compileMdxImpl(file: string): Promise<{
 										} else if (childNode.type === 'strong' || childNode.type === 'emphasis') {
 											// For formatting like bold/italic, just extract the text content
 											return extractText(childNode.children || [])
-										} else if (childNode.children) {
+										} else if ('children' in childNode && childNode.children) {
 											// For other nodes with children, recursively extract text
 											return extractText(childNode.children)
 										}

--- a/packages/workshop-utils/src/compile-mdx.server.ts
+++ b/packages/workshop-utils/src/compile-mdx.server.ts
@@ -243,7 +243,7 @@ async function compileMdxImpl(file: string): Promise<{
 											return extractText(childNode.children || [])
 										} else if ('children' in childNode && childNode.children) {
 											// For other nodes with children, recursively extract text
-											return extractText(childNode.children)
+											return extractText(childNode.children || [])
 										}
 										return ''
 									}).join('')

--- a/packages/workshop-utils/src/compile-mdx.server.ts
+++ b/packages/workshop-utils/src/compile-mdx.server.ts
@@ -232,7 +232,7 @@ async function compileMdxImpl(file: string): Promise<{
 							if (title) return
 							if (node.depth === 1) {
 								// Extract plain text content, preserving inline code but stripping other formatting
-								const extractText = (nodes: PhrasingContent[]): string => {
+								const extractText = (nodes: Array<PhrasingContent>): string => {
 									return nodes.map((childNode: PhrasingContent) => {
 										if (childNode.type === 'text') {
 											return childNode.value

--- a/packages/workshop-utils/src/compile-mdx.test.ts
+++ b/packages/workshop-utils/src/compile-mdx.test.ts
@@ -1,0 +1,83 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { describe, it, expect } from 'vitest'
+import { compileMdx } from './compile-mdx.server.js'
+
+describe('compileMdx title parsing', () => {
+	it('should extract title with backticks correctly', async () => {
+		// Create a temporary MDX file with backticks in title
+		const testMdxContent = `# Title with \`something\` highlighted
+
+This is some content.
+`
+		
+		const tempDir = os.tmpdir()
+		const testFile = path.join(tempDir, 'test-backtick-title.mdx')
+		
+		try {
+			fs.writeFileSync(testFile, testMdxContent)
+			
+			const result = await compileMdx(testFile)
+			
+			// The title should be extracted correctly, preserving the full text
+			expect(result.title).toBe('Title with `something` highlighted')
+		} finally {
+			// Clean up the temporary file
+			try {
+				fs.unlinkSync(testFile)
+			} catch {
+				// Ignore cleanup errors
+			}
+		}
+	})
+
+	it('should extract title with multiple backticks correctly', async () => {
+		const testMdxContent = `# \`Code\` and \`more code\` in title
+
+This is some content.
+`
+		
+		const tempDir = os.tmpdir()
+		const testFile = path.join(tempDir, 'test-multiple-backticks.mdx')
+		
+		try {
+			fs.writeFileSync(testFile, testMdxContent)
+			
+			const result = await compileMdx(testFile)
+			
+			expect(result.title).toBe('`Code` and `more code` in title')
+		} finally {
+			try {
+				fs.unlinkSync(testFile)
+			} catch {
+				// Ignore cleanup errors
+			}
+		}
+	})
+
+	it('should extract title with mixed markdown correctly', async () => {
+		const testMdxContent = `# Title with \`code\` and **bold** text
+
+This is some content.
+`
+		
+		const tempDir = os.tmpdir()
+		const testFile = path.join(tempDir, 'test-mixed-markdown.mdx')
+		
+		try {
+			fs.writeFileSync(testFile, testMdxContent)
+			
+			const result = await compileMdx(testFile)
+			
+			// Bold formatting should be stripped, but backticks preserved
+			expect(result.title).toBe('Title with `code` and bold text')
+		} finally {
+			try {
+				fs.unlinkSync(testFile)
+			} catch {
+				// Ignore cleanup errors
+			}
+		}
+	})
+})


### PR DESCRIPTION
- Fix issue where titles containing backticks were truncated
- Update title extraction to handle all child nodes in heading
- Preserve inline code formatting (backticks) in titles
- Strip other formatting like bold/italic to clean text
- Add comprehensive tests for title extraction scenarios

Resolves #349