### PR TITLE
fix: filter Sentry Replay iframe prototype TypeError (EPICSHOP-HF)

### DIFF
--- a/packages/workshop-app/app/utils/sentry-filters.ts
+++ b/packages/workshop-app/app/utils/sentry-filters.ts
@@ -277,6 +277,43 @@ export function isUnexpectedServerErrorNoise(event: SentryEventWithException) {
 	)
 }
 
+function frameLooksLikeSentryReplay(frame: {
+	filename?: string
+	module?: string
+}) {
+	const filename = frame.filename ?? ''
+	const module = frame.module ?? ''
+	return (
+		filename.includes('@sentry-internal/replay') ||
+		module.includes('@sentry-internal/replay')
+	)
+}
+
+/**
+ * Sentry Session Replay patches iframe load / attachShadow and can throw
+ * TypeError "Cannot read properties of undefined (reading 'prototype')" when
+ * exercise preview iframes load. Entire stack is SDK frames — not product.
+ */
+export function isSentryReplayIframeNoise(event: SentryEventWithException) {
+	return getExceptionValues(event).some((value) => {
+		if (value.type !== 'TypeError') return false
+		const text = exceptionValueText(value)
+		if (!/reading ['"]prototype['"]/i.test(text)) return false
+
+		const frames = value.stacktrace?.frames ?? []
+		if (!frames.length) return false
+
+		return frames.some((frame) => {
+			if (!frameLooksLikeSentryReplay(frame)) return false
+			const fn = frame.function ?? ''
+			return (
+				/onIframeLoad|observeAttachShadow|patchAttachShadow/i.test(fn) ||
+				/HTMLIFrameElement/i.test(fn)
+			)
+		})
+	})
+}
+
 export function isClientSentryNoise(event: SentryEventWithException) {
 	return (
 		isProcessingPictureInPictureRequest(event) ||
@@ -289,6 +326,7 @@ export function isClientSentryNoise(event: SentryEventWithException) {
 		isDomMutationNoise(event) ||
 		isPlaygroundClientNoise(event) ||
 		isReactExtensionRenderLoopNoise(event) ||
-		isUnexpectedServerErrorNoise(event)
+		isUnexpectedServerErrorNoise(event) ||
+		isSentryReplayIframeNoise(event)
 	)
 }

--- a/packages/workshop-app/tests/sentry-filters.test.ts
+++ b/packages/workshop-app/tests/sentry-filters.test.ts
@@ -9,6 +9,7 @@ import {
 	isPlaygroundClientNoise,
 	isProcessingPictureInPictureRequest,
 	isReactExtensionRenderLoopNoise,
+	isSentryReplayIframeNoise,
 	isSessionStorageAccessDenied,
 	isStaleRouteResultNoise,
 	isUnexpectedServerErrorNoise,
@@ -428,6 +429,95 @@ test('drops React Router opaque Unexpected Server Error client mirrors (aha)', (
 		isUnexpectedServerErrorNoise({
 			exception: {
 				values: [{ type: 'TypeError', value: 'Unexpected Server Error' }],
+			},
+		}),
+	).toBe(false)
+})
+
+test('drops Sentry Replay iframe/attachShadow prototype TypeErrors (aha)', () => {
+	const replayIframeEvent = {
+		exception: {
+			values: [
+				{
+					type: 'TypeError',
+					value: "Cannot read properties of undefined (reading 'prototype')",
+					stacktrace: {
+						frames: [
+							{
+								filename:
+									'../../../../../node_modules/@sentry/browser/build/npm/esm/prod/helpers.js',
+								function: 'r',
+								inApp: false,
+							},
+							{
+								filename:
+									'../../../../../node_modules/@sentry-internal/replay/build/npm/esm/index.js',
+								function: 'HTMLIFrameElement.<anonymous>',
+								module: '@sentry-internal/replay/build/npm/esm/index',
+								inApp: false,
+							},
+							{
+								filename:
+									'../../../../../node_modules/@sentry-internal/replay/build/npm/esm/index.js',
+								function: 's.onIframeLoad',
+								module: '@sentry-internal/replay/build/npm/esm/index',
+								inApp: false,
+							},
+							{
+								filename:
+									'../../../../../node_modules/@sentry-internal/replay/build/npm/esm/index.js',
+								function: 'TT.observeAttachShadow',
+								module: '@sentry-internal/replay/build/npm/esm/index',
+								inApp: false,
+							},
+							{
+								filename:
+									'../../../../../node_modules/@sentry-internal/replay/build/npm/esm/index.js',
+								function: 'TT.patchAttachShadow',
+								module: '@sentry-internal/replay/build/npm/esm/index',
+								inApp: false,
+							},
+						],
+					},
+				},
+			],
+		},
+	}
+
+	expect(isSentryReplayIframeNoise(replayIframeEvent)).toBe(true)
+	expect(isClientSentryNoise(replayIframeEvent)).toBe(true)
+
+	// Same message without Replay iframe/shadow frames must still alert.
+	expect(
+		isSentryReplayIframeNoise({
+			exception: {
+				values: [
+					{
+						type: 'TypeError',
+						value: "Cannot read properties of undefined (reading 'prototype')",
+						stacktrace: {
+							frames: [
+								{
+									filename: '/app/utils/something.ts',
+									function: 'extendThing',
+									inApp: true,
+								},
+							],
+						},
+					},
+				],
+			},
+		}),
+	).toBe(false)
+	expect(
+		isSentryReplayIframeNoise({
+			exception: {
+				values: [
+					{
+						type: 'TypeError',
+						value: "Cannot read properties of undefined (reading 'prototype')",
+					},
+				],
 			},
 		}),
 	).toBe(false)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Filters client-side Sentry noise from **EPICSHOP-HF** (`TypeError: Cannot read properties of undefined (reading 'prototype')` on `/exercise/02`).

### Root cause

Not an app bug. The event stack is entirely Sentry Session Replay instrumentation:

- `HTMLIFrameElement.<anonymous>` → `onIframeLoad` → `observeAttachShadow` → `patchAttachShadow` in `@sentry-internal/replay`
- Mechanism: `auto.browser.browserapierrors.addEventListener`

Workshop exercise pages load preview iframes heavily; Replay’s iframe/shadow patches can throw this `TypeError` when those iframes load. Nothing in-app is on the stack.

### Change

- Add `isSentryReplayIframeNoise` in `packages/workshop-app/app/utils/sentry-filters.ts`
- Match only `TypeError` + `reading 'prototype'` **and** Replay frames for iframe load / attachShadow
- Wire into `isClientSentryNoise` (used by client `beforeSend`)
- Unit tests covering the EPICSHOP-HF stack shape and negative cases

### Outcome

**filtered** — after merge, ignore the Sentry issue so it stops paging; future identical events are dropped client-side.

### Risk

Low: narrow client filter with tests; no product behavior change.

### Validation

- Local: `npx vitest run --project app-sentry-noise` → 16 passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-109cde62-de19-43f9-b51e-25aecbbedd3d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-109cde62-de19-43f9-b51e-25aecbbedd3d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

