### PR TITLE
fix: tolerate OAuth token sets missing token_type/scope (EPICSHOP-HG)

### DIFF
--- a/packages/workshop-cli/src/commands/auth.ts
+++ b/packages/workshop-cli/src/commands/auth.ts
@@ -46,8 +46,8 @@ export type AuthLogoutOptions = {
 
 const TokenSetSchema = z.object({
 	access_token: z.string(),
-	token_type: z.string(),
-	scope: z.string(),
+	token_type: z.string().default('Bearer'),
+	scope: z.string().default(''),
 })
 
 const AuthInfoSchema = z.object({

--- a/packages/workshop-utils/src/db-auth-token-set.test.ts
+++ b/packages/workshop-utils/src/db-auth-token-set.test.ts
@@ -1,0 +1,38 @@
+import { expect, test } from 'vitest'
+import { TokenSetSchema } from './db.server.ts'
+
+test('defaults missing OAuth token_type and scope (aha: EPICSHOP-HG)', () => {
+	expect(TokenSetSchema.parse({ access_token: 'tok' })).toEqual({
+		access_token: 'tok',
+		token_type: 'Bearer',
+		scope: '',
+	})
+})
+
+test('defaults undefined OAuth token_type and scope (aha: EPICSHOP-HG)', () => {
+	expect(
+		TokenSetSchema.parse({
+			access_token: 'tok',
+			token_type: undefined,
+			scope: undefined,
+		}),
+	).toEqual({
+		access_token: 'tok',
+		token_type: 'Bearer',
+		scope: '',
+	})
+})
+
+test('preserves provided OAuth token_type and scope', () => {
+	expect(
+		TokenSetSchema.parse({
+			access_token: 'tok',
+			token_type: 'Bearer',
+			scope: 'openid profile',
+		}),
+	).toEqual({
+		access_token: 'tok',
+		token_type: 'Bearer',
+		scope: 'openid profile',
+	})
+})

--- a/packages/workshop-utils/src/db.server.ts
+++ b/packages/workshop-utils/src/db.server.ts
@@ -11,10 +11,13 @@ import { saveJSON, loadJSON, migrateLegacyData } from './data-storage.server.ts'
 // Attempt migration from legacy ~/.epicshop
 await migrateLegacyData().catch(() => {})
 
-const TokenSetSchema = z.object({
+// OAuth token responses often omit token_type/scope; require only access_token.
+// Defaults match CLI auth persistence so incomplete local auth data is readable
+// instead of being treated as a corrupted database (EPICSHOP-HG).
+export const TokenSetSchema = z.object({
 	access_token: z.string(),
-	token_type: z.string(),
-	scope: z.string(),
+	token_type: z.string().default('Bearer'),
+	scope: z.string().default(''),
 })
 const defaultSubtitlePreferences = {
 	id: null,
@@ -362,7 +365,16 @@ export async function setAuthInfo({
 	productHost?: string
 }) {
 	const data = await readDb()
-	const authInfo = AuthInfoSchema.parse({ id, tokenSet, email, name })
+	const authInfo = AuthInfoSchema.parse({
+		id,
+		tokenSet: {
+			access_token: tokenSet.access_token,
+			token_type: tokenSet.token_type ?? 'Bearer',
+			scope: tokenSet.scope ?? '',
+		},
+		email,
+		name,
+	})
 	const host = productHost ?? tryGetWorkshopProductHost()
 	if (host) {
 		await saveJSON({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sentry [EPICSHOP-HG](https://kent-c-dodds-tech-llc.sentry.io/issues/7670258937/) reported a handled `ZodError` while reading local `data.json` during `warmCache` → `getAuthInfo` → `readDb`.

The stored auth entry for `www.epicreact.dev` had an OAuth `tokenSet` with `access_token` but missing `token_type` and `scope`. Those fields are optional in OAuth responses; the CLI already defaults them when saving (`Bearer` / `''`), but the shared DB schema required both strings. Parse failure was treated as a corrupted database file (retries, Sentry capture, move to `.bkp`), which wipes preferences along with auth.

## Fix

- Default `token_type` to `'Bearer'` and `scope` to `''` in `TokenSetSchema` (workshop-utils + CLI auth schema).
- Normalize those fields in `setAuthInfo` on write.
- Aha tests for EPICSHOP-HG.

## Risk

Low — isolated schema/default change with tests; preserves existing complete token sets.

## Testing / CI

- Local: `nx run @epic-web/workshop-utils:test -- db-auth-token-set` and `npm run validate`
- CI: validate run [31755625281](https://github.com/epicweb-dev/epicshop/actions/runs/31755625281) green (incl. Windows Example after retrigger)

## Merge note

Autonomous squash-merge was blocked by `epicweb-dev` OAuth App access restrictions; PR is ready for Kent to merge. After merge, resolve EPICSHOP-HG in the squash commit.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-679247f4-cf9f-4d90-9964-6bd7b2965882?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-679247f4-cf9f-4d90-9964-6bd7b2965882&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

