### PR TITLE
fix: filter esbuild playground compile failures in Sentry (EPICSHOP-HH)

### DIFF
--- a/packages/workshop-app/instrument.js
+++ b/packages/workshop-app/instrument.js
@@ -1,6 +1,5 @@
-import path from 'node:path'
 import { isbot } from 'isbot'
-import { isServerEnvironmentNoise } from './sentry-server-filters.js'
+import { isServerSentryNoise } from './sentry-server-filters.js'
 
 // Dynamic import of Sentry modules with error handling
 const Sentry = await import('@sentry/react-router').catch((error) => {
@@ -80,15 +79,7 @@ Sentry?.init({
 		if (isLearnerApiRequest(event)) {
 			return null
 		}
-		if (isServerEnvironmentNoise(event)) {
-			return null
-		}
-		const isPlaygroundError = event.exception?.values?.some((value) =>
-			value.stacktrace?.frames?.some((frame) =>
-				frame.filename?.includes(`${path.sep}playground${path.sep}`),
-			),
-		)
-		if (isPlaygroundError) {
+		if (isServerSentryNoise(event)) {
 			return null
 		}
 		return event

--- a/packages/workshop-app/sentry-server-filters.d.ts
+++ b/packages/workshop-app/sentry-server-filters.d.ts
@@ -1,8 +1,18 @@
-export function isServerEnvironmentNoise(event: {
+type ServerSentryEvent = {
 	exception?: {
 		values?: Array<{
 			type?: string
 			value?: string
+			stacktrace?: {
+				frames?: Array<{
+					filename?: string
+				}>
+			}
 		}>
 	}
-}): boolean
+}
+
+export function isEsbuildCompileFailureNoise(event: ServerSentryEvent): boolean
+export function isPlaygroundServerNoise(event: ServerSentryEvent): boolean
+export function isServerEnvironmentNoise(event: ServerSentryEvent): boolean
+export function isServerSentryNoise(event: ServerSentryEvent): boolean

--- a/packages/workshop-app/sentry-server-filters.js
+++ b/packages/workshop-app/sentry-server-filters.js
@@ -4,10 +4,63 @@
  */
 
 /**
+ * @param {{ exception?: { values?: Array<{ type?: string, value?: string, stacktrace?: { frames?: Array<{ filename?: string }> } }> } }} event
+ */
+function getExceptionValues(event) {
+	return event.exception?.values ?? []
+}
+
+/**
+ * esbuild's failureErrorWithLog message when compiling learner app TS/TSX.
+ * Always learner code or local dependency setup — never an epicshop product bug.
+ *
  * @param {{ exception?: { values?: Array<{ type?: string, value?: string }> } }} event
  */
+export function isEsbuildCompileFailureNoise(event) {
+	return getExceptionValues(event).some((value) => {
+		const text = typeof value.value === 'string' ? value.value : ''
+		return /^Build failed with \d+ errors?:/i.test(text)
+	})
+}
+
+/**
+ * Learner playground / exercise sandbox failures. Stack frames are often only
+ * esbuild internals; the playground path then appears only in the message.
+ *
+ * @param {{ exception?: { values?: Array<{ type?: string, value?: string, stacktrace?: { frames?: Array<{ filename?: string }> } }> } }} event
+ */
+export function isPlaygroundServerNoise(event) {
+	return getExceptionValues(event).some((value) => {
+		const frames = value.stacktrace?.frames ?? []
+		if (
+			frames.some((frame) => {
+				const filename = frame.filename ?? ''
+				return (
+					filename.includes('/playground/') ||
+					filename.includes('\\playground\\')
+				)
+			})
+		) {
+			return true
+		}
+
+		const text = typeof value.value === 'string' ? value.value : ''
+		if (!text) return false
+
+		// esbuild messages like: ../../../../playground/index.tsx:1:25: ERROR: ...
+		return (
+			/(?:^|[/\\])playground[/\\]/i.test(text) &&
+			(/Build failed with \d+ errors?:/i.test(text) ||
+				/ERROR: Could not resolve/i.test(text))
+		)
+	})
+}
+
+/**
+ * @param {{ exception?: { values?: Array<{ type?: string, value?: string, stacktrace?: { frames?: Array<{ filename?: string }> } }> } }} event
+ */
 export function isServerEnvironmentNoise(event) {
-	const values = event.exception?.values ?? []
+	const values = getExceptionValues(event)
 	return values.some((value) => {
 		const type = value.type ?? ''
 		const text = typeof value.value === 'string' ? value.value : ''
@@ -28,4 +81,15 @@ export function isServerEnvironmentNoise(event) {
 			/^ENOENT: no such file or directory/i.test(text)
 		)
 	})
+}
+
+/**
+ * @param {{ exception?: { values?: Array<{ type?: string, value?: string, stacktrace?: { frames?: Array<{ filename?: string }> } }> } }} event
+ */
+export function isServerSentryNoise(event) {
+	return (
+		isServerEnvironmentNoise(event) ||
+		isEsbuildCompileFailureNoise(event) ||
+		isPlaygroundServerNoise(event)
+	)
 }

--- a/packages/workshop-app/tests/sentry-filters.test.ts
+++ b/packages/workshop-app/tests/sentry-filters.test.ts
@@ -16,7 +16,12 @@ import {
 	pictureInPictureRequiresUserActivationMessage,
 	processingPictureInPictureRequestMessage,
 } from '../app/utils/sentry-filters.ts'
-import { isServerEnvironmentNoise } from '../sentry-server-filters.js'
+import {
+	isServerEnvironmentNoise,
+	isEsbuildCompileFailureNoise,
+	isPlaygroundServerNoise,
+	isServerSentryNoise,
+} from '../sentry-server-filters.js'
 
 test('matches the Picture-in-Picture processing DOMException exactly', () => {
 	expect(
@@ -596,4 +601,82 @@ test('drops learner-machine server environment noise (aha)', () => {
 			},
 		}),
 	).toBe(false)
+})
+
+test('drops esbuild learner compile failures with only esbuild frames (EPICSHOP-HH aha)', () => {
+	const epicshopHh = {
+		exception: {
+			values: [
+				{
+					type: 'Error',
+					value:
+						'Build failed with 3 errors:\n../../../../playground/index.tsx:1:25: ERROR: Could not resolve "react"\n../../../../playground/index.tsx:2:26: ERROR: Could not resolve "react-dom/client"\n../../../../playground/index.tsx:5:8: ERROR: Could not resolve "react/jsx-runtime"',
+					stacktrace: {
+						frames: [
+							{
+								filename:
+									'/Users/learner/workshop/epicshop/node_modules/esbuild/lib/main.js',
+								function: 'failureErrorWithLog',
+							},
+						],
+					},
+				},
+			],
+		},
+	}
+	expect(isEsbuildCompileFailureNoise(epicshopHh)).toBe(true)
+	expect(isPlaygroundServerNoise(epicshopHh)).toBe(true)
+	expect(isServerSentryNoise(epicshopHh)).toBe(true)
+	expect(isServerEnvironmentNoise(epicshopHh)).toBe(false)
+})
+
+test('does not drop unrelated Build failed product errors', () => {
+	expect(
+		isEsbuildCompileFailureNoise({
+			exception: {
+				values: [{ type: 'Error', value: 'Build failed' }],
+			},
+		}),
+	).toBe(false)
+	expect(
+		isPlaygroundServerNoise({
+			exception: {
+				values: [
+					{
+						type: 'Error',
+						value: 'Something broke while saving preferences',
+						stacktrace: {
+							frames: [
+								{
+									filename: '/app/routes/settings.tsx',
+								},
+							],
+						},
+					},
+				],
+			},
+		}),
+	).toBe(false)
+})
+
+test('drops playground server noise from learner stack frames', () => {
+	expect(
+		isPlaygroundServerNoise({
+			exception: {
+				values: [
+					{
+						type: 'TypeError',
+						value: 'x is not a function',
+						stacktrace: {
+							frames: [
+								{
+									filename: '/Users/learner/workshop/playground/index.tsx',
+								},
+							],
+						},
+					},
+				],
+			},
+		}),
+	).toBe(true)
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Closes the server Sentry filter gap behind [EPICSHOP-HH](https://kent-c-dodds-tech-llc.sentry.io/issues/7676225720/): esbuild `Build failed with N errors` (e.g. playground missing `react`) had only esbuild frames, so the old playground frame-path filter never matched.
- Moves playground server noise into `sentry-server-filters.js`, matches message-based playground paths, and drops the esbuild compile-failure signature.
- Current `compileTs` already catches these on modern app versions; this stops residual / older-path reports from paging.

## Test plan
- [x] `npx vitest run packages/workshop-app/tests/sentry-filters.test.ts`
- [x] `npx vitest run packages/workshop-app/tests/published-files.test.ts`
- [ ] CI green

Event evidence: learner on `@epic-web/workshop-app@6.41.3` (current latest `6.90.28`) hitting `/app/playground/index.tsx` with unresolved `react` / `react-dom` / `jsx-runtime`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e0fdb8a6-127d-4543-b66e-388eed4e115d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e0fdb8a6-127d-4543-b66e-388eed4e115d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

