### PR TITLE
fix: stop reporting handled corrupted cache JSON to Sentry (EPICSHOP-HK)

### DIFF
--- a/packages/workshop-app/sentry-server-filters.d.ts
+++ b/packages/workshop-app/sentry-server-filters.d.ts
@@ -10,8 +10,10 @@ type ServerSentryEvent = {
 			}
 		}>
 	}
+	tags?: Record<string, unknown>
 }
 
+export function isCorruptedCacheFileNoise(event: ServerSentryEvent): boolean
 export function isEsbuildCompileFailureNoise(event: ServerSentryEvent): boolean
 export function isPlaygroundServerNoise(event: ServerSentryEvent): boolean
 export function isServerEnvironmentNoise(event: ServerSentryEvent): boolean

--- a/packages/workshop-app/sentry-server-filters.js
+++ b/packages/workshop-app/sentry-server-filters.js
@@ -12,10 +12,15 @@ function getExceptionValues(event) {
 
 /**
  * Handled FS-cache JSON corruption on learner machines (null-byte / truncated
- * files under epicshop Cache). readJSONWithRetries deletes and continues;
- * reporting these only produced triage noise (EPICSHOP-HK and siblings).
+ * files under the platform epicshop cache dir). readJSONWithRetries deletes and
+ * continues; reporting these only produced triage noise (EPICSHOP-HK and siblings).
  *
- * @param {{ exception?: { values?: Array<{ type?: string, value?: string }> }, tags?: Record<string, string | number | boolean | null | undefined> }} event
+ * Cache roots (see resolveCacheDir):
+ * - Windows: …/epicshop/Cache/…
+ * - macOS: …/Library/Caches/epicshop/…
+ * - Linux: …/.cache/epicshop/…
+ *
+ * @param {{ exception?: { values?: Array<{ type?: string, value?: string }> }, tags?: Record<string, unknown> }} event
  */
 export function isCorruptedCacheFileNoise(event) {
 	if (event.tags?.error_type === 'corrupted_cache_file') return true
@@ -25,7 +30,11 @@ export function isCorruptedCacheFileNoise(event) {
 		const text = typeof value.value === 'string' ? value.value : ''
 		if (type !== 'SyntaxError' && !/SyntaxError/i.test(text)) return false
 		if (!/is not valid JSON/i.test(text)) return false
-		return /[/\\]epicshop[/\\]Cache[/\\]/i.test(text)
+		return (
+			/[/\\]epicshop[/\\]Cache[/\\]/i.test(text) ||
+			/[/\\]Library[/\\]Caches[/\\]epicshop[/\\]/i.test(text) ||
+			/[/\\]\.cache[/\\]epicshop[/\\]/i.test(text)
+		)
 	})
 }
 

--- a/packages/workshop-app/sentry-server-filters.js
+++ b/packages/workshop-app/sentry-server-filters.js
@@ -4,10 +4,29 @@
  */
 
 /**
- * @param {{ exception?: { values?: Array<{ type?: string, value?: string, stacktrace?: { frames?: Array<{ filename?: string }> } }> } }} event
+ * @param {{ exception?: { values?: Array<{ type?: string, value?: string, stacktrace?: { frames?: Array<{ filename?: string }> } }> }, tags?: Record<string, string | number | boolean | null | undefined> }} event
  */
 function getExceptionValues(event) {
 	return event.exception?.values ?? []
+}
+
+/**
+ * Handled FS-cache JSON corruption on learner machines (null-byte / truncated
+ * files under epicshop Cache). readJSONWithRetries deletes and continues;
+ * reporting these only produced triage noise (EPICSHOP-HK and siblings).
+ *
+ * @param {{ exception?: { values?: Array<{ type?: string, value?: string }> }, tags?: Record<string, string | number | boolean | null | undefined> }} event
+ */
+export function isCorruptedCacheFileNoise(event) {
+	if (event.tags?.error_type === 'corrupted_cache_file') return true
+
+	return getExceptionValues(event).some((value) => {
+		const type = value.type ?? ''
+		const text = typeof value.value === 'string' ? value.value : ''
+		if (type !== 'SyntaxError' && !/SyntaxError/i.test(text)) return false
+		if (!/is not valid JSON/i.test(text)) return false
+		return /[/\\]epicshop[/\\]Cache[/\\]/i.test(text)
+	})
 }
 
 /**
@@ -90,6 +109,7 @@ export function isServerSentryNoise(event) {
 	return (
 		isServerEnvironmentNoise(event) ||
 		isEsbuildCompileFailureNoise(event) ||
-		isPlaygroundServerNoise(event)
+		isPlaygroundServerNoise(event) ||
+		isCorruptedCacheFileNoise(event)
 	)
 }

--- a/packages/workshop-app/tests/sentry-filters.test.ts
+++ b/packages/workshop-app/tests/sentry-filters.test.ts
@@ -704,7 +704,20 @@ test('drops handled corrupted epicshop Cache JSON SyntaxErrors (EPICSHOP-HK aha)
 					{
 						type: 'SyntaxError',
 						value:
-							'/home/learner/.cache/epicshop/Cache/abc/DiscordCache/def: Unexpected token \'<\', "<html>"... is not valid JSON',
+							"/Users/learner/Library/Caches/epicshop/abc/EpicApiCache/def: Unexpected token '<', \"<html>\"... is not valid JSON",
+					},
+				],
+			},
+		}),
+	).toBe(true)
+	expect(
+		isCorruptedCacheFileNoise({
+			exception: {
+				values: [
+					{
+						type: 'SyntaxError',
+						value:
+							'/home/learner/.cache/epicshop/abc/DiscordCache/def: Unexpected token \'<\', "<html>"... is not valid JSON',
 					},
 				],
 			},

--- a/packages/workshop-app/tests/sentry-filters.test.ts
+++ b/packages/workshop-app/tests/sentry-filters.test.ts
@@ -18,6 +18,7 @@ import {
 } from '../app/utils/sentry-filters.ts'
 import {
 	isServerEnvironmentNoise,
+	isCorruptedCacheFileNoise,
 	isEsbuildCompileFailureNoise,
 	isPlaygroundServerNoise,
 	isServerSentryNoise,
@@ -679,4 +680,46 @@ test('drops playground server noise from learner stack frames', () => {
 			},
 		}),
 	).toBe(true)
+})
+
+test('drops handled corrupted epicshop Cache JSON SyntaxErrors (EPICSHOP-HK aha)', () => {
+	const epicshopHk = {
+		tags: { error_type: 'corrupted_cache_file' },
+		exception: {
+			values: [
+				{
+					type: 'SyntaxError',
+					value:
+						"C:\\Users\\ankit\\AppData\\Local\\epicshop\\Cache\\67952d5900442ecda2c3142860f13b26\\EpicApiCache\\015b7b336203003c3edc0026304476bf: Unexpected token '\u0000', \"\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\"... is not valid JSON",
+				},
+			],
+		},
+	}
+	expect(isCorruptedCacheFileNoise(epicshopHk)).toBe(true)
+	expect(isServerSentryNoise(epicshopHk)).toBe(true)
+	expect(
+		isCorruptedCacheFileNoise({
+			exception: {
+				values: [
+					{
+						type: 'SyntaxError',
+						value:
+							'/home/learner/.cache/epicshop/Cache/abc/DiscordCache/def: Unexpected token \'<\', "<html>"... is not valid JSON',
+					},
+				],
+			},
+		}),
+	).toBe(true)
+	expect(
+		isCorruptedCacheFileNoise({
+			exception: {
+				values: [
+					{
+						type: 'SyntaxError',
+						value: 'Unexpected token } in JSON at position 12',
+					},
+				],
+			},
+		}),
+	).toBe(false)
 })

--- a/packages/workshop-app/tests/sentry-filters.test.ts
+++ b/packages/workshop-app/tests/sentry-filters.test.ts
@@ -690,7 +690,7 @@ test('drops handled corrupted epicshop Cache JSON SyntaxErrors (EPICSHOP-HK aha)
 				{
 					type: 'SyntaxError',
 					value:
-						"C:\\Users\\ankit\\AppData\\Local\\epicshop\\Cache\\67952d5900442ecda2c3142860f13b26\\EpicApiCache\\015b7b336203003c3edc0026304476bf: Unexpected token '\u0000', \"\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\"... is not valid JSON",
+						'C:\\Users\\ankit\\AppData\\Local\\epicshop\\Cache\\67952d5900442ecda2c3142860f13b26\\EpicApiCache\\015b7b336203003c3edc0026304476bf: Unexpected token \'\u0000\', "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"... is not valid JSON',
 				},
 			],
 		},

--- a/packages/workshop-cli/src/utils/sentry-cli-filters.test.ts
+++ b/packages/workshop-cli/src/utils/sentry-cli-filters.test.ts
@@ -69,7 +69,7 @@ test('drops handled corrupted epicshop Cache JSON SyntaxErrors (EPICSHOP-HK aha)
 					{
 						type: 'SyntaxError',
 						value:
-							"C:\\Users\\ankit\\AppData\\Local\\epicshop\\Cache\\67952d5900442ecda2c3142860f13b26\\EpicApiCache\\015b7b336203003c3edc0026304476bf: Unexpected token '\u0000', \"\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\"... is not valid JSON",
+							'C:\\Users\\ankit\\AppData\\Local\\epicshop\\Cache\\67952d5900442ecda2c3142860f13b26\\EpicApiCache\\015b7b336203003c3edc0026304476bf: Unexpected token \'\u0000\', "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"... is not valid JSON',
 					},
 				],
 			},

--- a/packages/workshop-cli/src/utils/sentry-cli-filters.test.ts
+++ b/packages/workshop-cli/src/utils/sentry-cli-filters.test.ts
@@ -82,14 +82,26 @@ test('drops handled corrupted epicshop Cache JSON SyntaxErrors (EPICSHOP-HK aha)
 					{
 						type: 'SyntaxError',
 						value:
-							'/Users/learner/Library/Caches/epicshop/Cache/abc/EpicApiCache/def: Unexpected token \'<\', "<html>"... is not valid JSON',
+							"/Users/learner/Library/Caches/epicshop/abc/EpicApiCache/def: Unexpected token '<', \"<html>\"... is not valid JSON",
+					},
+				],
+			},
+		}),
+	).toBe(true)
+	expect(
+		isExpectedCliSentryNoise({
+			exception: {
+				values: [
+					{
+						type: 'SyntaxError',
+						value:
+							'/home/learner/.cache/epicshop/abc/DiscordCache/def: Unexpected token \'<\', "<html>"... is not valid JSON',
 					},
 				],
 			},
 		}),
 	).toBe(true)
 })
-
 test('keeps unrelated CLI errors', () => {
 	expect(
 		isExpectedCliSentryNoise({

--- a/packages/workshop-cli/src/utils/sentry-cli-filters.test.ts
+++ b/packages/workshop-cli/src/utils/sentry-cli-filters.test.ts
@@ -60,11 +60,53 @@ test('drops unsupported Node styleText and broken local package installs', () =>
 	).toBe(true)
 })
 
+test('drops handled corrupted epicshop Cache JSON SyntaxErrors (EPICSHOP-HK aha)', () => {
+	expect(
+		isExpectedCliSentryNoise({
+			tags: { error_type: 'corrupted_cache_file' },
+			exception: {
+				values: [
+					{
+						type: 'SyntaxError',
+						value:
+							"C:\\Users\\ankit\\AppData\\Local\\epicshop\\Cache\\67952d5900442ecda2c3142860f13b26\\EpicApiCache\\015b7b336203003c3edc0026304476bf: Unexpected token '\u0000', \"\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\"... is not valid JSON",
+					},
+				],
+			},
+		}),
+	).toBe(true)
+	expect(
+		isExpectedCliSentryNoise({
+			exception: {
+				values: [
+					{
+						type: 'SyntaxError',
+						value:
+							'/Users/learner/Library/Caches/epicshop/Cache/abc/EpicApiCache/def: Unexpected token \'<\', "<html>"... is not valid JSON',
+					},
+				],
+			},
+		}),
+	).toBe(true)
+})
+
 test('keeps unrelated CLI errors', () => {
 	expect(
 		isExpectedCliSentryNoise({
 			exception: {
 				values: [{ type: 'Error', value: 'Failed to clone workshop repo' }],
+			},
+		}),
+	).toBe(false)
+	expect(
+		isExpectedCliSentryNoise({
+			exception: {
+				values: [
+					{
+						type: 'SyntaxError',
+						value: 'Unexpected token } in JSON at position 12',
+					},
+				],
 			},
 		}),
 	).toBe(false)

--- a/packages/workshop-cli/src/utils/sentry-cli-filters.ts
+++ b/packages/workshop-cli/src/utils/sentry-cli-filters.ts
@@ -20,8 +20,13 @@ function exceptionValueText(value: SentryExceptionValue) {
 
 /**
  * Handled FS-cache JSON corruption on learner machines (null-byte / truncated
- * files under epicshop Cache). readJSONWithRetries deletes and continues;
- * reporting these only produced triage noise (EPICSHOP-HK and siblings).
+ * files under the platform epicshop cache dir). readJSONWithRetries deletes and
+ * continues; reporting these only produced triage noise (EPICSHOP-HK and siblings).
+ *
+ * Cache roots (see resolveCacheDir):
+ * - Windows: …/epicshop/Cache/…
+ * - macOS: …/Library/Caches/epicshop/…
+ * - Linux: …/.cache/epicshop/…
  */
 export function isCorruptedCacheFileNoise(event: SentryEventWithException) {
 	if (event.tags?.error_type === 'corrupted_cache_file') return true
@@ -31,7 +36,11 @@ export function isCorruptedCacheFileNoise(event: SentryEventWithException) {
 		const text = exceptionValueText(value)
 		if (type !== 'SyntaxError' && !/SyntaxError/i.test(text)) return false
 		if (!/is not valid JSON/i.test(text)) return false
-		return /[/\\]epicshop[/\\]Cache[/\\]/i.test(text)
+		return (
+			/[/\\]epicshop[/\\]Cache[/\\]/i.test(text) ||
+			/[/\\]Library[/\\]Caches[/\\]epicshop[/\\]/i.test(text) ||
+			/[/\\]\.cache[/\\]epicshop[/\\]/i.test(text)
+		)
 	})
 }
 

--- a/packages/workshop-cli/src/utils/sentry-cli-filters.ts
+++ b/packages/workshop-cli/src/utils/sentry-cli-filters.ts
@@ -7,6 +7,7 @@ type SentryEventWithException = {
 	exception?: {
 		values?: Array<SentryExceptionValue>
 	}
+	tags?: Record<string, unknown>
 }
 
 function getExceptionValues(event: SentryEventWithException) {
@@ -18,10 +19,29 @@ function exceptionValueText(value: SentryExceptionValue) {
 }
 
 /**
+ * Handled FS-cache JSON corruption on learner machines (null-byte / truncated
+ * files under epicshop Cache). readJSONWithRetries deletes and continues;
+ * reporting these only produced triage noise (EPICSHOP-HK and siblings).
+ */
+export function isCorruptedCacheFileNoise(event: SentryEventWithException) {
+	if (event.tags?.error_type === 'corrupted_cache_file') return true
+
+	return getExceptionValues(event).some((value) => {
+		const type = value.type ?? ''
+		const text = exceptionValueText(value)
+		if (type !== 'SyntaxError' && !/SyntaxError/i.test(text)) return false
+		if (!/is not valid JSON/i.test(text)) return false
+		return /[/\\]epicshop[/\\]Cache[/\\]/i.test(text)
+	})
+}
+
+/**
  * Expected CLI UX: user ran an interactive command without a TTY / in CI, or
  * cancelled an inquirer prompt with Ctrl-C. Not a product defect.
  */
 export function isExpectedCliSentryNoise(event: SentryEventWithException) {
+	if (isCorruptedCacheFileNoise(event)) return true
+
 	return getExceptionValues(event).some((value) => {
 		const type = value.type ?? ''
 		const text = exceptionValueText(value)

--- a/packages/workshop-utils/src/cache.server.ts
+++ b/packages/workshop-utils/src/cache.server.ts
@@ -39,12 +39,6 @@ type CompiledCodeResult = {
 }
 type OgCacheValue = string | Uint8Array
 
-// Throttle repeated Sentry reports for corrupted cache files to reduce noise
-const corruptedReportThrottle = remember(
-	'epic:cache:corruption-throttle',
-	() => new LRUCache<string, number>({ max: 2000, ttl: 60_000 }),
-)
-
 const ensuredWorkshopCacheMetadata = remember(
 	'epic:cache:ensured-workshop-cache-metadata',
 	() => new Set<string>(),
@@ -487,28 +481,9 @@ async function readJSONWithRetries(filePath: string): Promise<any | null> {
 					continue
 				}
 
-				// Final attempt failed: optionally report and delete file
-				if (getEnv().SENTRY_DSN && getEnv().EPICSHOP_IS_PUBLISHED) {
-					const throttleKey = `readJSON:${md5(filePath)}`
-					if (!corruptedReportThrottle.has(throttleKey)) {
-						corruptedReportThrottle.set(throttleKey, Date.now())
-						try {
-							const Sentry = await import('@sentry/react-router')
-							Sentry.withScope((scope) => {
-								scope.setLevel('warning')
-								scope.setTag('error_type', 'corrupted_cache_file')
-								scope.setExtra('filePath', filePath)
-								scope.setExtra('errorMessage', (error as Error).message)
-								scope.setExtra('retryAttempts', attempt)
-								Sentry.captureException(error)
-							})
-						} catch (sentryError) {
-							console.error('Failed to log to Sentry:', sentryError)
-						}
-					}
-				}
-
-				// Always delete corrupted files so subsequent reads can refetch
+				// Final attempt failed: delete so subsequent reads can refetch.
+				// Do not report to Sentry — learner disk/AV corruption is handled
+				// locally and was generating recurring triage noise (EPICSHOP-HK).
 				try {
 					await fsExtra.remove(filePath)
 					console.warn(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sentry EPICSHOP-HK (and siblings HP/HN/HM) are **handled** `SyntaxError`s from null-byte / invalid JSON under the learner `epicshop/Cache` directory. `readJSONWithRetries` already retries, deletes the file, and continues — but it also called `Sentry.captureException` with `error_type: corrupted_cache_file`, which created recurring triage noise on Windows learner machines.

## Changes

- Stop intentional Sentry reporting for corrupted FS cache JSON in `cache.server.ts` (keep delete + local warn).
- Filter residual `corrupted_cache_file` / `epicshop/Cache` + `is not valid JSON` SyntaxErrors in CLI and server `beforeSend`.
- Tests covering the EPICSHOP-HK signature.

## Risk

Low — removes noise reporting for already-recovered local cache corruption; does not change cache read/write recovery behavior beyond skipping Sentry.

## Siblings

- EPICSHOP-HP (DiscordCache)
- EPICSHOP-HN (DiffPatchCache)
- EPICSHOP-HM (EpicApiCache)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-26a3ec21-634c-49bc-9056-82d361436b54?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-26a3ec21-634c-49bc-9056-82d361436b54&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

